### PR TITLE
Enable comment update and delete

### DIFF
--- a/app/components/Comments/Comment.js
+++ b/app/components/Comments/Comment.js
@@ -2,34 +2,58 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import GGButton from 'components/GGButton';
 import { BlogPreviewContent, SubSection } from 'components/Typography';
+import CommentInput from './CommentInput';
 
 import './comments.scss';
 
 class Comment extends React.Component {
   static propTypes = {
-    onCommentStartEdit: PropTypes.func.isRequired,
-    onCommentDeleted: PropTypes.func.isRequired,
     user: PropTypes.object,
     comment: PropTypes.object,
+    updateComment: PropTypes.func.isRequired,
+    updatingComment: PropTypes.bool,
+    updateCommentError: PropTypes.bool,
+    updateCommentSuccess: PropTypes.bool,
   };
 
   static defaultProps = {
     user: null,
     comment: null,
+    updatingComment: false,
+    updateCommentError: false,
+    updateCommentSuccess: false,
   };
 
   constructor(props) {
     super(props);
+
+    this.state = { editing: false };
   }
+
+  componentWillReceiveProps = newProps => {
+    if (
+      this.props.updatingComment &&
+      !newProps.updatingComment &&
+      !newProps.updateCommentError
+    ) {
+      this.setState({ editing: false });
+    }
+  };
 
   render() {
     const {
-      onCommentStartEdit,
       user,
       className,
       centered,
       comment,
-      onCommentDeleted,
+      updateComment,
+      updatingComment,
+      updateCommentError,
+      updateCommentSuccess,
+      deleteComment,
+      deletingComment,
+      deleteCommentSuccess,
+      deleteCommentError,
       ...rest
     } = this.props;
 
@@ -57,12 +81,10 @@ class Comment extends React.Component {
     ];
 
     let displayName = 'Anon';
-    if (comment.ownerUname && comment.ownerUname !== 'Anon') {
+    if (comment.ownerUname) {
       displayName = comment.ownerUname;
     } else if (comment.displayName) {
       displayName = comment.displayName;
-    } else if (comment.authorId) {
-      displayName = `User ${comment.authorId}`;
     }
 
     return (
@@ -71,10 +93,42 @@ class Comment extends React.Component {
         className="comments__component"
         name={`${displayName}`}
       >
-        <BlogPreviewContent
-          supportedFeatures={supportedFeatures}
-          content={contentFinal}
-        />
+        {!this.state.editing && (
+          <BlogPreviewContent
+            supportedFeatures={supportedFeatures}
+            content={contentFinal}
+          />
+        )}
+        {this.state.editing && (
+          <CommentInput
+            comment={comment}
+            user={user}
+            centered={centered}
+            submitLabel="Update comment"
+            onSubmit={updateComment}
+            updatingComment={updatingComment}
+            updateCommentError={updateCommentError}
+            updateCommentSuccess={updateCommentSuccess}
+          />
+        )}
+        {canEdit && !this.state.editing && (
+          <div>
+            <GGButton onClick={() => this.setState({ editing: true })}>
+              Edit
+            </GGButton>
+            {!comment.deleted && (
+              <GGButton
+                disabled={deletingComment}
+                onClick={() => {
+                  deleteComment(comment);
+                }}
+                destructive
+              >
+                Delete
+              </GGButton>
+            )}
+          </div>
+        )}
       </SubSection>
     );
   }

--- a/app/components/Comments/CommentInput.js
+++ b/app/components/Comments/CommentInput.js
@@ -22,7 +22,7 @@ class CommentInput extends React.Component {
 
   constructor(props) {
     super(props);
-    this.state = { comment: { name: '', comment: '' } };
+    this.state = { comment: this.props.comment || { name: '', comment: '' } };
   }
 
   onCommentChanged = newValue => {
@@ -38,6 +38,10 @@ class CommentInput extends React.Component {
       creatingComment,
       createCommentSuccess,
       createCommentError,
+      updateComment,
+      updatingComment,
+      updateCommentError,
+      updateCommentSuccess,
       submitLabel,
       ...rest
     } = this.props;
@@ -75,7 +79,7 @@ class CommentInput extends React.Component {
             onSubmit={() => onSubmit(this.state.comment)}
             onDataChanged={this.onCommentChanged}
             centered={centered}
-            disabled={creatingComment}
+            disabled={creatingComment || updatingComment}
             presubmitText={
               <Fragment>
                 {'Comments support **'}

--- a/app/components/Comments/Comments.js
+++ b/app/components/Comments/Comments.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import CommentInput from './CommentInput';
 import Comment from './Comment';
-import { LoggedInOnly } from 'components/Auth';
+import { DebugObject, LoggedInOnly } from 'components/Auth';
 import { NotificationComp } from 'components/Notifications';
 import { Section, SubSection } from 'components/Typography';
 
@@ -47,12 +47,17 @@ class Comments extends React.Component {
       newComment,
       onNewCommentChanged,
       onCommentSubmit,
-      onCommentStartEdit,
       newCommentBeingCreated,
       createComment,
       commentCreationError,
       updateComment,
-      onCommentDeleted,
+      updatingComment,
+      updateCommentSuccess,
+      updateCommentError,
+      deleteComment,
+      deletingComment,
+      deleteCommentSuccess,
+      deleteCommentError,
       ...rest
     } = this.props;
 
@@ -77,7 +82,18 @@ class Comments extends React.Component {
           />
         ) : (
           commentsFiltered.map(comment => (
-            <Comment user={user} comment={comment} />
+            <Comment
+              user={user}
+              comment={comment}
+              updateComment={updateComment}
+              updatingComment={updatingComment}
+              updateCommentError={updateCommentError}
+              updateCommentSuccess={updateCommentSuccess}
+              deleteComment={deleteComment}
+              deletingComment={deletingComment}
+              deleteCommentError={deleteCommentError}
+              deleteCommentSuccess={deleteCommentSuccess}
+            />
           ))
         );
     }
@@ -85,6 +101,30 @@ class Comments extends React.Component {
     return (
       <Section name="Comments" className={classNameFinal.join(' ')}>
         {commentsComponent}
+        <DebugObject
+          debugTitle="Comments"
+          debugObject={{
+            user,
+            comments,
+            centered,
+            pageId,
+            className,
+            newComment,
+            onNewCommentChanged,
+            onCommentSubmit,
+            newCommentBeingCreated,
+            createComment,
+            commentCreationError,
+            updateComment,
+            updatingComment,
+            updateCommentSuccess,
+            updateCommentError,
+            deleteComment,
+            deletingComment,
+            deleteCommentSuccess,
+            deleteCommentError,
+          }}
+        />
       </Section>
     );
   }

--- a/app/containers/Comments/Comments.js
+++ b/app/containers/Comments/Comments.js
@@ -28,6 +28,16 @@ export default class CommentsContainer extends React.Component {
       creatingComment,
       createCommentSuccess,
       createCommentError,
+
+      updateComment,
+      updatingComment,
+      updateCommentSuccess,
+      updateCommentError,
+
+      deleteComment,
+      deletingComment,
+      deleteCommentSuccess,
+      deleteCommentError,
       ...rest
     } = this.props;
 
@@ -53,6 +63,14 @@ export default class CommentsContainer extends React.Component {
             creatingComment,
             createCommentSuccess,
             createCommentError,
+            updateComment,
+            updatingComment,
+            updateCommentSuccess,
+            updateCommentError,
+            deleteComment,
+            deletingComment,
+            deleteCommentSuccess,
+            deleteCommentError,
           }}
         />
         <LoadingCover
@@ -66,6 +84,14 @@ export default class CommentsContainer extends React.Component {
               user={user}
               centered={false}
               pageId={pageId}
+              updateComment={updateComment}
+              updatingComment={updatingComment}
+              updateCommentError={updateCommentError}
+              updateCommentSuccess={updateCommentSuccess}
+              deleteComment={deleteComment}
+              deletingComment={deletingComment}
+              deleteCommentError={deleteCommentError}
+              deleteCommentSuccess={deleteCommentSuccess}
             />
           )}
           {comments && (
@@ -78,6 +104,10 @@ export default class CommentsContainer extends React.Component {
               creatingComment={creatingComment}
               createCommentError={createCommentError}
               createCommentSuccess={createCommentSuccess}
+              updateComment={updateComment}
+              updatingComment={updatingComment}
+              updateCommentError={updateCommentError}
+              updateCommentSuccess={updateCommentSuccess}
             />
           )}
         </LoadingCover>

--- a/app/containers/Comments/actions.js
+++ b/app/containers/Comments/actions.js
@@ -6,6 +6,12 @@ import {
   CREATE_COMMENT,
   CREATE_COMMENT_SUCCESS,
   CREATE_COMMENT_ERROR,
+  UPDATE_COMMENT,
+  UPDATE_COMMENT_SUCCESS,
+  UPDATE_COMMENT_ERROR,
+  DELETE_COMMENT,
+  DELETE_COMMENT_SUCCESS,
+  DELETE_COMMENT_ERROR,
 } from './constants';
 
 export function reloadComments(pageId) {
@@ -53,6 +59,50 @@ export function commentCreateSuccess(comment) {
 export function commentCreateError(error) {
   return {
     type: CREATE_COMMENT_ERROR,
+    error,
+  };
+}
+
+export function updateComment(comment) {
+  console.log(`actions.updateComment`);
+  return {
+    type: UPDATE_COMMENT,
+    comment,
+  };
+}
+
+export function commentUpdateSuccess(comment) {
+  return {
+    type: UPDATE_COMMENT_SUCCESS,
+    comment,
+  };
+}
+
+export function commentUpdateError(error) {
+  return {
+    type: UPDATE_COMMENT_ERROR,
+    error,
+  };
+}
+
+export function deleteComment(comment) {
+  console.log(`actions.deleteComment`);
+  return {
+    type: DELETE_COMMENT,
+    comment,
+  };
+}
+
+export function commentDeleteSuccess(comment) {
+  return {
+    type: DELETE_COMMENT_SUCCESS,
+    comment,
+  };
+}
+
+export function commentDeleteError(error) {
+  return {
+    type: DELETE_COMMENT_ERROR,
     error,
   };
 }

--- a/app/containers/Comments/constants.js
+++ b/app/containers/Comments/constants.js
@@ -7,3 +7,11 @@ export const CREATE_COMMENT = 'boilerplate/Comments/CREATE_COMMENT';
 export const CREATE_COMMENT_ERROR = 'boilerplate/Comments/CREATE_COMMENT_ERROR';
 export const CREATE_COMMENT_SUCCESS =
   'boilerplate/Comments/CREATE_COMMENT_SUCCESS';
+export const UPDATE_COMMENT = 'boilerplate/Comments/UPDATE_COMMENT';
+export const UPDATE_COMMENT_ERROR = 'boilerplate/Comments/UPDATE_COMMENT_ERROR';
+export const UPDATE_COMMENT_SUCCESS =
+  'boilerplate/Comments/UPDATE_COMMENT_SUCCESS';
+export const DELETE_COMMENT = 'boilerplate/Comments/DELETE_COMMENT';
+export const DELETE_COMMENT_ERROR = 'boilerplate/Comments/DELETE_COMMENT_ERROR';
+export const DELETE_COMMENT_SUCCESS =
+  'boilerplate/Comments/DELETE_COMMENT_SUCCESS';

--- a/app/containers/Comments/index.js
+++ b/app/containers/Comments/index.js
@@ -11,9 +11,20 @@ import {
   makeSelectCreatingComment,
   makeSelectCreateCommentError,
   makeSelectCreateCommentSuccess,
+  makeSelectUpdatingComment,
+  makeSelectUpdateCommentError,
+  makeSelectUpdateCommentSuccess,
+  makeSelectDeletingComment,
+  makeSelectDeleteCommentError,
+  makeSelectDeleteCommentSuccess,
 } from './selectors';
 import { makeSelectUser } from 'containers/App/selectors';
-import { updateComment, loadComments, createComment } from './actions';
+import {
+  updateComment,
+  deleteComment,
+  loadComments,
+  createComment,
+} from './actions';
 import reducer from './reducer';
 import saga from './saga';
 import Comments from './Comments';
@@ -22,6 +33,7 @@ const mapDispatchToProps = dispatch => ({
   loadComments: pageId => dispatch(loadComments(pageId)),
   createComment: comment => dispatch(createComment(comment)),
   updateComment: comment => dispatch(updateComment(comment)),
+  deleteComment: comment => dispatch(deleteComment(comment)),
 });
 
 const mapStateToProps = createStructuredSelector({
@@ -35,6 +47,14 @@ const mapStateToProps = createStructuredSelector({
   creatingComment: makeSelectCreatingComment(),
   createCommentSuccess: makeSelectCreateCommentSuccess(),
   createCommentError: makeSelectCreateCommentError(),
+
+  updatingComment: makeSelectUpdatingComment(),
+  updateCommentSuccess: makeSelectUpdateCommentSuccess(),
+  updateCommentError: makeSelectUpdateCommentError(),
+
+  deletingComment: makeSelectDeletingComment(),
+  deleteCommentSuccess: makeSelectDeleteCommentSuccess(),
+  deleteCommentError: makeSelectDeleteCommentError(),
 });
 
 const withConnect = connect(

--- a/app/containers/Comments/reducer.js
+++ b/app/containers/Comments/reducer.js
@@ -11,6 +11,9 @@ import {
   UPDATE_COMMENT,
   UPDATE_COMMENT_ERROR,
   UPDATE_COMMENT_SUCCESS,
+  DELETE_COMMENT,
+  DELETE_COMMENT_ERROR,
+  DELETE_COMMENT_SUCCESS,
 } from './constants';
 
 const initialState = fromJS({
@@ -60,11 +63,22 @@ function appReducer(state = initialState, action) {
         .set('updateCommentError', false)
         .set('comment', action.comment);
     case UPDATE_COMMENT_SUCCESS:
-      return state.set('updating', false);
+      return state.set('updating', false).set('updateCommentSuccess', true);
     case UPDATE_COMMENT_ERROR:
       return state
         .set('updateCommentError', action.error)
         .set('updating', false);
+    case DELETE_COMMENT:
+      return state
+        .set('deleting', true)
+        .set('deleteCommentError', false)
+        .set('comment', action.comment);
+    case DELETE_COMMENT_SUCCESS:
+      return state.set('deleting', false).set('deleteCommentSuccess', true);
+    case DELETE_COMMENT_ERROR:
+      return state
+        .set('deleteCommentError', action.error)
+        .set('deleting', false);
     default:
       return state;
   }

--- a/app/containers/Comments/selectors.js
+++ b/app/containers/Comments/selectors.js
@@ -75,6 +75,24 @@ const makeSelectUpdateCommentSuccess = () =>
     commentsState => commentsState.get('updateCommentSuccess'),
   );
 
+const makeSelectDeletingComment = () =>
+  createSelector(
+    selectComments,
+    commentsState => commentsState.get('deleting'),
+  );
+
+const makeSelectDeleteCommentError = () =>
+  createSelector(
+    selectComments,
+    commentsState => commentsState.get('deleteCommentError'),
+  );
+
+const makeSelectDeleteCommentSuccess = () =>
+  createSelector(
+    selectComments,
+    commentsState => commentsState.get('deleteCommentSuccess'),
+  );
+
 export {
   selectComments,
   makeSelectPageId,
@@ -88,5 +106,8 @@ export {
   makeSelectCreateCommentSuccess,
   makeSelectUpdatingComment,
   makeSelectUpdateCommentError,
+  makeSelectDeletingComment,
+  makeSelectDeleteCommentError,
+  makeSelectDeleteCommentSuccess,
   makeSelectUpdateCommentSuccess,
 };


### PR DESCRIPTION
Reenable deletion / updating existing comments.
Should be possible for any comment created by the current user, or all comments if the current user is admin.

Note that each comment should be responsible for knowing if it is being edited, and storing it's new value in the current state. Only when updateComment is called should the new comment value be passed to the redux container